### PR TITLE
Update repository metadata cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ To set e.g. a specific `baseurl` (e.g. a local mirror) define it for each reposi
 
     yum_repo_default_options:
       epel:
-        baseurl: 'http://mirror.example.com/epel/$releasever/$basearch'
+        baseurl: 'http://mirror.example.com/pub/epel/$releasever/Everything/$basearch'
       epel-debuginfo:
-        baseurl: 'http://mirror.example.com/epel/$releasever/$basearch/debug'
+        baseurl: 'http://mirror.example.com/pub/epel/$releasever/Everything/$basearch/debug'
       epel-source:
-        baseurl: 'http://mirror.example.com/epel/$releasever/$basearch/SRPMS'
+        baseurl: 'http://mirror.example.com/pub/epel/$releasever/Everything/SRPMS'
 
 The EPEL `.repo` file contains multiple repository definitions. For each of them the `baseurl` option is set accordingly.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,3 +48,6 @@ yum_repo_default_options: {}
 # Configuration dictionary of custom repository options. For more information
 # see `yum_repo_options` above.
 yum_repo_custom_options: {}
+
+# Update repository metadata cache
+yum_repo_update_cache: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,13 +24,13 @@ yum_repo_file: '/etc/yum.repos.d/epel.repo'
 #
 #   yum_repo_options:
 #     epel:
-#       baseurl: 'http://pkgs.{{ ansible_domain }}/epel/$releasever/$basearch'
+#       baseurl: 'http://mirror.example.com/pub/epel/$releasever/Everything/$basearch'
 #       enabled: '1'
 #     epel-debuginfo:
-#       baseurl: 'http://pkgs.{{ ansible_domain }}/epel/$releasever/$basearch/debug'
+#       baseurl: 'http://mirror.example.com/pub/epel/$releasever/Everything/$basearch/debug'
 #       enabled: '0'
 #     epel-source:
-#       baseurl: 'http://pkgs.{{ ansible_domain }}/epel/$releasever/$basearch/SRPMS'
+#       baseurl: 'http://mirror.example.com/pub/epel/$releasever/Everything/SRPMS'
 #       enabled: '0'
 #
 # By default this variable will be combined of `yum_repo_default_options`

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,3 +28,7 @@
   loop: '{{ yum_repo_options.keys() | list }}'
   loop_control:
     loop_var: yum_repo_include_repo
+
+- name: Include tasks to update repository metadata cache
+  include_tasks: update_cache.yml
+  when: yum_repo_update_cache | bool

--- a/tasks/update_cache.yml
+++ b/tasks/update_cache.yml
@@ -12,7 +12,7 @@
   when: ansible_pkg_mgr == 'dnf'
 
 - name: Update repository metadata cache with yum
-  dnf:
+  yum:
     disablerepo: '{{ "*"
                      if (yum_repo_options.keys() | list | length > 0)
                      else omit }}'

--- a/tasks/update_cache.yml
+++ b/tasks/update_cache.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Update repository metadata cache with dnf
+  dnf:
+    disablerepo: '{{ "*"
+                     if (yum_repo_options.keys() | list | length > 0)
+                     else omit }}'
+    enablerepo: '{{ yum_repo_options.keys() | list | join(",")
+                    if (yum_repo_options.keys() | list | length > 0)
+                    else omit }}'
+    update_cache: yes
+  when: ansible_pkg_mgr == 'dnf'
+
+- name: Update repository metadata cache with yum
+  dnf:
+    disablerepo: '{{ "*"
+                     if (yum_repo_options.keys() | list | length > 0)
+                     else omit }}'
+    enablerepo: '{{ yum_repo_options.keys() | list | join(",")
+                    if (yum_repo_options.keys() | list | length > 0)
+                    else omit }}'
+    update_cache: yes
+  when: ansible_pkg_mgr == 'yum'


### PR DESCRIPTION
If a list of repositories can be read from `yum_repo_options` only update the metadata of those new/changed repositories otherwise trigger a cache update of all repositories defined for the package manager.

Also fix example URLs for EPEL mirror to correspond to path used for existing mirrors.