### PR TITLE
Verify repository configuration in molecule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro:
-          - centos7
-          - centos8
+        image:
+          - 'centos:7'
+          - 'centos:8'
 
     steps:
       - name: Check out the codebase.
@@ -63,4 +63,4 @@ jobs:
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_DISTRO: ${{ matrix.distro }}
+          MOLECULE_IMAGE: ${{ matrix.image }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2018-2020 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
+# Copyright (C) 2018-2021 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
 # SPDX-License-Identifier: Apache-2.0
 
 # Yum repository release package. If this variable has an empty value, no
@@ -8,7 +8,7 @@ yum_repo_release_pkg: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest
 
 # Repository GPG public key. If this variable has an empty value, no GPG
 # public key will be imported.
-yum_repo_gpg_key: '/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}'
+yum_repo_gpg_key: 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}'
 
 # Repository file path
 yum_repo_file: '/etc/yum.repos.d/epel.repo'

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -13,5 +13,8 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      command_warnings: False
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/podman/molecule.yml
+++ b/molecule/podman/molecule.yml
@@ -13,5 +13,8 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      command_warnings: False
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/molecule/podman/molecule.yml
+++ b/molecule/podman/molecule.yml
@@ -9,7 +9,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: ${MOLECULE_IMAGE:-centos:8}
     pre_build_image: true
 provisioner:
   name: ansible

--- a/molecule/podman/verify.yml
+++ b/molecule/podman/verify.yml
@@ -4,8 +4,29 @@
 
 - name: Verify
   hosts: all
-  gather_facts: false
+
   tasks:
-  - name: Example assertion
-    assert:
-      that: true
+    - name: Check repository configuration file
+      stat:
+        path: '/etc/yum.repos.d/epel.repo'
+      register: verify_register_repofile
+
+    - name: Verify that repository configuration is available
+      assert:
+        quiet: true
+        that: verify_register_repofile.stat.exists
+
+    - name: List repositories
+      changed_when: false
+      command: '{{ "dnf" if ansible_distribution == "Fedora" else "yum" }} repolist'
+      register: verify_register_repolist
+
+    - name: Verify that repository is in repolist
+      assert:
+        quiet: true
+        that: '{% set _repo = [] %}{%
+                  for _line in verify_register_repolist.stdout_lines %}{%
+                    if (_line | regex_search("^epel")) %}{%
+                      set _ = _repo.append(_line) %}{%
+                    endif %}{%
+                  endfor %}{{ _repo | length > 0 }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2018-2020 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
+# Copyright (C) 2018-2021 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
 # SPDX-License-Identifier: Apache-2.0
 
 - name: Check if repository configuration is available
@@ -7,14 +7,6 @@
   stat:
     path: '{{ yum_repo_file }}'
   register: yum_repo_register_repofile
-
-- name: Install repository package
-  package:
-    name: '{{ yum_repo_release_pkg }}'
-    state: present
-  when:
-    - not yum_repo_register_repofile.stat.exists
-    - yum_repo_release_pkg | length > 0
 
 - name: Import repository GPG public key
   ignore_errors: '{{ ansible_check_mode }}'
@@ -24,6 +16,14 @@
   when:
     - not yum_repo_register_repofile.stat.exists
     - yum_repo_gpg_key | length > 0
+
+- name: Install repository package
+  package:
+    name: '{{ yum_repo_release_pkg }}'
+    state: present
+  when:
+    - not yum_repo_register_repofile.stat.exists
+    - yum_repo_release_pkg | length > 0
 
 - name: Include tasks to configure repositories
   include_tasks: repo_config.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,22 +8,9 @@
     path: '{{ yum_repo_file }}'
   register: yum_repo_register_repofile
 
-- name: Import repository GPG public key
-  ignore_errors: '{{ ansible_check_mode }}'
-  rpm_key:
-    key: '{{ yum_repo_gpg_key }}'
-    state: present
-  when:
-    - not yum_repo_register_repofile.stat.exists
-    - yum_repo_gpg_key | length > 0
-
-- name: Install repository package
-  package:
-    name: '{{ yum_repo_release_pkg }}'
-    state: present
-  when:
-    - not yum_repo_register_repofile.stat.exists
-    - yum_repo_release_pkg | length > 0
+- name: Include tasks to setup repository package and GPG key
+  include_tasks: repo_setup.yml
+  when: not yum_repo_register_repofile.stat.exists
 
 - name: Include tasks to configure repositories
   include_tasks: repo_config.yml

--- a/tasks/repo_setup.yml
+++ b/tasks/repo_setup.yml
@@ -1,0 +1,28 @@
+---
+# Copyright (C) 2021 Reto Gantenbein <reto.gantenbein@linuxmonk.ch>
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Import repository remote GPG public key
+  ignore_errors: '{{ ansible_check_mode }}'
+  rpm_key:
+    key: '{{ yum_repo_gpg_key }}'
+    state: present
+  when:
+    - yum_repo_gpg_key | length > 0
+    - yum_repo_gpg_key | regex_search('^http')
+
+- name: Install repository package
+  package:
+    name: '{{ yum_repo_release_pkg }}'
+    state: present
+  when:
+    - yum_repo_release_pkg | length > 0
+
+- name: Import repository local GPG public key
+  ignore_errors: '{{ ansible_check_mode }}'
+  rpm_key:
+    key: '{{ yum_repo_gpg_key }}'
+    state: present
+  when:
+    - yum_repo_gpg_key | length > 0
+    - yum_repo_gpg_key | regex_search('^/')


### PR DESCRIPTION
* Switch container image to `centos:8` upstream because the `geerlingguy/docker-centos8-ansible:latest` image already had the EPEL repository predefined.
* Fix bug that repo release RPM cannot be verified when related GPG was not trusted yet. This means when given a GPG key via URL it will be added before trying to install the release RPM otherwise afterwards (for the case that the release RPM is already trusted but contains a GPG key for other repositories).
* Add some minimal repo verification tasks.