### PR TITLE
Fix yamllint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
     strategy:
       matrix:
         distro:
-          - 'centos7'
           - 'rockylinux8'
           - 'rockylinux9'
 

--- a/.yamllint
+++ b/.yamllint
@@ -1,33 +1,19 @@
 ---
-# Based on ansible-lint config
 extends: default
-
 rules:
-  braces:
-    max-spaces-inside: 1
-    level: error
-  brackets:
-    max-spaces-inside: 1
-    level: error
-  colons:
-    max-spaces-after: -1
-    level: error
-  commas:
-    max-spaces-after: -1
-    level: error
-  comments: disable
-  comments-indentation: disable
-  document-start: disable
-  empty-lines:
-    max: 3
-    level: error
-  hyphens:
-    level: error
-  indentation: disable
-  key-duplicates: enable
-  line-length: disable
-  new-line-at-end-of-file: disable
-  new-lines:
-    type: unix
-  trailing-spaces: disable
   truthy: disable
+  # ansible-lint compatibility
+  # https://ansible.readthedocs.io/projects/lint/rules/yaml/#yamllint-configuration
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  document-start: disable
+  line-length:
+    max: 120
+    level: warning
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,8 @@
 
 # Yum repository release package. If this variable has an empty value, no
 # release package will be installed.
-yum_repo_release_pkg: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm'
+yum_repo_release_pkg: >
+  https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
 
 # Repository GPG public key. If this variable has an empty value, no GPG
 # public key will be imported.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,6 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - "7"
         - "8"
         - "9"
     - name: Fedora
@@ -25,6 +24,5 @@ galaxy_info:
     - dnf
     - epel
     - rpm
-    - yum
 
 dependencies: []

--- a/molecule/docker/requirements.txt
+++ b/molecule/docker/requirements.txt
@@ -1,4 +1,4 @@
-ansible
+ansible-core==2.16.7
 docker
 molecule
 molecule-plugins[docker]

--- a/molecule/podman/collections.yml
+++ b/molecule/podman/collections.yml
@@ -1,3 +1,3 @@
 ---
 collections:
-- community.general
+  - community.general

--- a/molecule/podman/requirements.txt
+++ b/molecule/podman/requirements.txt
@@ -1,3 +1,3 @@
-ansible
+ansible-core==2.16.7
 molecule
 molecule-plugins[podman]

--- a/tasks/update_cache.yml
+++ b/tasks/update_cache.yml
@@ -11,15 +11,3 @@
                     if (yum_repo_options.keys() | list | length > 0)
                     else omit }}'
     update_cache: yes
-  when: ansible_pkg_mgr == 'dnf'
-
-- name: Update repository metadata cache with yum
-  ansible.builtin.yum:
-    disablerepo: '{{ "*"
-                     if (yum_repo_options.keys() | list | length > 0)
-                     else omit }}'
-    enablerepo: '{{ yum_repo_options.keys() | list | join(",")
-                    if (yum_repo_options.keys() | list | length > 0)
-                    else omit }}'
-    update_cache: yes
-  when: ansible_pkg_mgr == 'yum'


### PR DESCRIPTION
During the last monthly CI run we had some new errors:
```
Run yamllint .
WARNING  Found incompatible custom yamllint configuration (.yamllint), please either remove the file or edit it to comply with:
  - comments.min-spaces-from-content must be 1
  - octal-values.forbid-implicit-octal must be true
  - octal-values.forbid-explicit-octal must be true.

Read https://ansible.readthedocs.io/projects/lint/rules/yaml/ for more details regarding why we have these requirements. Fix mode will not be available.
WARNING  Listing 5 violation(s) that are fatal
name[template]: Jinja templates should only be at the end of 'name' (warning)
tasks/repo_config.yml:5 Task/Handler: {{ yum_repo_include_repo }} - Set repository options

name[template]: Jinja templates should only be at the end of 'name' (warning)
tasks/repo_config.yml:23 Task/Handler: {{ yum_repo_include_repo }} - Cleanup redundant metalink option

name[template]: Jinja templates should only be at the end of 'name' (warning)
tasks/repo_config.yml:36 Task/Handler: {{ yum_repo_include_repo }} - Cleanup redundant mirrorlist option

name[template]: Jinja templates should only be at the end of 'name' (warning)
tasks/repo_config.yml:49 Task/Handler: {{ yum_repo_include_repo }} - Cleanup redundant baseurl option

fqcn[action-core]: Use FQCN for builtin module actions (ansible.builtin.yum).
tasks/update_cache.yml:16 Use `ansible.builtin.dnf` or `ansible.legacy.dnf` instead.
Warning: Jinja templates should only be at the end of 'name'

Warning: Jinja templates should only be at the end of 'name'
Warning: Jinja templates should only be at the end of 'name'
Warning: Jinja templates should only be at the end of 'name'
Error: Use FQCN for builtin module actions (ansible.builtin.yum).
Read documentation for instructions on how to ignore specific rule violations.

                 Rule Violation Summary                  
 count tag               profile    rule associated tags 
     4 name[template]    moderate   idiom (warning)      
     1 fqcn[action-core] production formatting           

Failed: 1 failure(s), 4 warning(s) on 9 files. Last profile that met the validation criteria was 'basic'. Rating: 1/5 star
Error: Process completed with exit code 2.
```