### PR TITLE
molecule: Use latest ansible-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
     strategy:
       matrix:
         distro:
-          - 'rockylinux8'
           - 'rockylinux9'
 
     steps:

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -10,7 +10,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/docker/requirements.txt
+++ b/molecule/docker/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core==2.16.7
+ansible-core
 docker
 molecule
 molecule-plugins[docker]

--- a/molecule/podman/molecule.yml
+++ b/molecule/podman/molecule.yml
@@ -10,7 +10,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux9}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/podman/requirements.txt
+++ b/molecule/podman/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core==2.16.7
+ansible-core
 molecule
 molecule-plugins[podman]


### PR DESCRIPTION
Also remove Rocky Linux 8 from the test matrix as it fails with nasty Python errors with Ansible >= 2.16.7:
```
  TASK [Gathering Facts] *********************************************************
  fatal: [instance]: FAILED! => {"ansible_facts": {}, "changed": false, "failed_modules": {"ansible.legacy.setup": {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "exception": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1738379962.7389805-2392-207152366153213/AnsiballZ_setup.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1738379962.7389805-2392-207152366153213/AnsiballZ_setup.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1738379962.7389805-2392-207152366153213/AnsiballZ_setup.py\", line 44, in invoke_module\n    from ansible.module_utils import basic\n  File \"<frozen importlib._bootstrap>\", line 971, in _find_and_load\n  File \"<frozen importlib._bootstrap>\", line 951, in _find_and_load_unlocked\n  File \"<frozen importlib._bootstrap>\", line 894, in _find_spec\n  File \"<frozen importlib._bootstrap_external>\", line 1157, in find_spec\n  File \"<frozen importlib._bootstrap_external>\", line 1131, in _get_spec\n  File \"<frozen importlib._bootstrap_external>\", line 1112, in _legacy_get_spec\n  File \"<frozen importlib._bootstrap>\", line 441, in spec_from_loader\n  File \"<frozen importlib._bootstrap_external>\", line 544, in spec_from_file_location\n  File \"/tmp/ansible_ansible.legacy.setup_payload_7qvph2xu/ansible_ansible.legacy.setup_payload.zip/ansible/module_utils/basic.py\", line 5\nSyntaxError: future feature annotations is not defined\n", "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1738379962.7389805-2392-207152366153213/AnsiballZ_setup.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1738379962.7389805-2392-207152366153213/AnsiballZ_setup.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1738379962.7389805-2392-207152366153213/AnsiballZ_setup.py\", line 44, in invoke_module\n    from ansible.module_utils import basic\n  File \"<frozen importlib._bootstrap>\", line 971, in _find_and_load\n  File \"<frozen importlib._bootstrap>\", line 951, in _find_and_load_unlocked\n  File \"<frozen importlib._bootstrap>\", line 894, in _find_spec\n  File \"<frozen importlib._bootstrap_external>\", line 1157, in find_spec\n  File \"<frozen importlib._bootstrap_external>\", line 1131, in _get_spec\n  File \"<frozen importlib._bootstrap_external>\", line 1112, in _legacy_get_spec\n  File \"<frozen importlib._bootstrap>\", line 441, in spec_from_loader\n  File \"<frozen importlib._bootstrap_external>\", line 544, in spec_from_file_location\n  File \"/tmp/ansible_ansible.legacy.setup_payload_7qvph2xu/ansible_ansible.legacy.setup_payload.zip/ansible/module_utils/basic.py\", line 5\nSyntaxError: future feature annotations is not defined\n", "module_stdout": "", "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error", "rc": 1}}, "msg": "The following modules failed to execute: ansible.legacy.setup\n"}
```
```
The following modules failed to execute: ansible.legacy.setup
MODULE FAILURE: No start of json char found
SyntaxError: future feature annotations is not defined
```